### PR TITLE
feat(ui): improve accessibility of sub-panel toggle

### DIFF
--- a/components/control-panel.tsx
+++ b/components/control-panel.tsx
@@ -259,6 +259,8 @@ export function ControlPanel({
           variant="ghost"
           size="sm"
           onClick={() => setIsSubPanelExpanded(!isSubPanelExpanded)}
+          aria-expanded={isSubPanelExpanded}
+          aria-controls="control-sub-panel"
           className="flex items-center justify-center gap-1 text-xs text-slate-600 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-100 transition-colors w-full h-6 py-0 px-2"
         >
           {isSubPanelExpanded ? (
@@ -266,10 +268,13 @@ export function ControlPanel({
           ) : (
             <ChevronDown className="h-4 w-4" />
           )}
-          More
+          {isSubPanelExpanded ? 'Less' : 'More'}
         </Button>
         {isSubPanelExpanded && (
-          <div className="p-2 rounded transition-colors duration-200">
+          <div
+            id="control-sub-panel"
+            className="p-2 rounded transition-colors duration-200"
+          >
             <SubPanel
               prototypeIdInput={prototypeIdInput}
               onPrototypeIdInputChange={onPrototypeIdInputChange}


### PR DESCRIPTION
## Summary
Improve the accessibility and clarity of the sub-panel toggle in `control-panel`.

## Motivation
Previously the toggle always displayed the label "More" and lacked explicit ARIA attributes. Screen reader users could not determine whether the sub-panel was currently expanded, nor what activating the button would do. Adding `aria-expanded` and linking the control to the panel region provides proper state semantics. Dynamically switching the label between "More" and "Less" gives clearer affordance for all users.

## Changes
- Add `aria-expanded` to the toggle button reflecting current state.
- Add `aria-controls` linking the button to the sub-panel container.
- Assign `id="control-sub-panel"` to the sub-panel `<div>`.
- Replace static text "More" with conditional label: `isSubPanelExpanded ? 'Less' : 'More'`.

## Accessibility Impact
Screen readers (e.g. VoiceOver, NVDA) will now announce the expanded/collapsed state. The control also exposes a direct relationship to its content region, improving navigation context. Visible label change reduces cognitive load: users immediately know the next action.

## Implementation Notes
Only `components/control-panel.tsx` was modified; no props or external APIs changed. This is a non-breaking UI improvement.

## Testing
Manual checks:
1. Toggle renders "More" initially with `aria-expanded="false"`.
2. Clicking updates to "Less" with `aria-expanded="true"` and reveals the panel.
3. Screen reader announces state change (VoiceOver: "Less, button, expanded").
4. Toggling again reverts label and hides panel.

Suggested follow-up (optional):
- Add a unit or accessibility test to assert ARIA state transitions.
- Consider keyboard focus styling for better visibility.
- Localize "More"/"Less" if i18n is planned.

## Risk & Rollback
Low risk. Rollback would simply revert the single file change.

## Screenshots / Demo
(If helpful, add a short GIF or screenshot showing the toggle before/after.)

Ready for review.
