### PR TITLE
docs(pr-template): add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+# PR Title
+
+- Use Conventional Commits in the title: `type(scope?): short summary`
+- Keep it under 50 chars when possible.
+
+## Summary
+
+Explain the change in 1-3 sentences.
+
+## Changes
+
+- List the key changes concisely
+- Note any visible UI, API, or behavior changes
+
+## Screenshots / Videos (optional)
+
+If relevant, attach images or videos.
+
+## How to Test
+
+1. Describe the minimal steps to verify
+2. Include expected results
+
+## Checklist
+
+- [ ] Tests added/updated if needed
+- [ ] Types updated and exported where needed
+- [ ] Lint passes locally
+- [ ] E2E/Manual checks for critical paths
+- [ ] Docs updated (README, comments, storybook, etc.)
+
+## Notes
+
+- Link related issues/PRs
+- Breaking changes and migration notes if any


### PR DESCRIPTION
### Summary
Add a standardized pull request template to improve contribution quality and consistency.

### Details
- Introduces `.github/pull_request_template.md` with sections for Summary, Changes, Testing, and Checklist.
- Encourages Conventional Commit style titles.

### Motivation
Provides contributors a clear structure, reducing review friction and ensuring key info (tests, docs, breaking changes) is supplied.

### Notes
No runtime code changes. Purely documentation/process improvement.
