### PR TITLE
fix(utils): collapse multiple spaces in extracted page title

### DIFF
--- a/__tests__/lib/playlist-builder.test.ts
+++ b/__tests__/lib/playlist-builder.test.ts
@@ -426,6 +426,19 @@ describe('playlist-builder ID utilities', () => {
       expect(extracted).toMatch(/Line 1\s+Line 2/);
     });
 
+    it('collapses multiple spaces into one when newlines are surrounded by whitespace', () => {
+      const html = `
+        <title>
+          Line 1
+          Line 2
+        </title>
+      `;
+      // Before fix: "Line 1  Line 2" (two spaces)
+      // After fix: "Line 1 Line 2" (one space)
+      const extracted = extractPageTitle(html);
+      expect(extracted).toBe('Line 1 Line 2');
+    });
+
     it('decodes HTML entities', () => {
       const html = '<title>A &amp; B</title>';
       expect(extractPageTitle(html)).toBe('A & B');

--- a/lib/utils/playlist-builder.ts
+++ b/lib/utils/playlist-builder.ts
@@ -306,7 +306,7 @@ export function extractPageTitle(html: string): string | null {
     return null;
   }
   const trimmed = match[1].trim();
-  const oneline = trimmed.replace(/[\r\n]+/g, ' ');
+  const oneline = trimmed.replace(/\s*[\r\n]+\s*/g, ' ');
   return decode(oneline);
 }
 


### PR DESCRIPTION
This PR improves the `extractPageTitle` utility to correctly handle whitespace when extracting page titles.

Previously, newlines were replaced with spaces, but if the HTML contained indentation (e.g. spaces or tabs) around the newlines, this could result in multiple consecutive spaces in the extracted title.

This change updates the regex to collapse any sequence of whitespace containing a newline into a single space.

**Example:**
```html
<title>
  Line 1
  Line 2
</title>
```
**Before:** `"Line 1  Line 2"` (two spaces)
**After:** `"Line 1 Line 2"` (one space)

This addresses feedback from a previous review.