### PR TITLE
feat: tune playlist delays and add unleashed mode

### DIFF
--- a/__tests__/lib/utils/validation.test.ts
+++ b/__tests__/lib/utils/validation.test.ts
@@ -176,4 +176,28 @@ describe('parseDirectLaunchParams', () => {
       expect(value.title).toBeUndefined();
     });
   });
+
+  describe('flags', () => {
+    it('parses unleashed from presence only', () => {
+      const params = new URLSearchParams('id=1&unleashed');
+      const value = expectSuccess(parseDirectLaunchParams(params));
+
+      expect(value.unleashed).toBe(true);
+    });
+
+    it('parses joe from presence only', () => {
+      const params = new URLSearchParams('id=1&joe');
+      const value = expectSuccess(parseDirectLaunchParams(params));
+
+      expect(value.joe).toBe(true);
+    });
+
+    it('omits flags when parameters are missing', () => {
+      const params = new URLSearchParams('id=1');
+      const value = expectSuccess(parseDirectLaunchParams(params));
+
+      expect(value.unleashed).toBeUndefined();
+      expect(value.joe).toBeUndefined();
+    });
+  });
 });

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -28,7 +28,24 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(function Header(
   const shortTitle = mugenShort + 'PP';
 
   // const playModeLabel = playMode === 'playlist' ? 'Playlist' : 'Normal';
-  const playModeLabel = playMode === 'playlist' ? ' ▶️' : 'Normal';
+  let playModeLabel: string;
+  switch (playMode) {
+    case 'playlist':
+      playModeLabel = 'Playlist️';
+      break;
+    case 'unleashed':
+      playModeLabel = 'Unleashed';
+      break;
+    case 'joe':
+      playModeLabel = 'Joe';
+      break;
+    case 'normal':
+      playModeLabel = 'Normal';
+      break;
+    default:
+      playModeLabel = 'Normal';
+      break;
+  }
 
   /**
    * Tailwind screen breakpoints (min-width):

--- a/lib/hooks/use-prototype-slots.ts
+++ b/lib/hooks/use-prototype-slots.ts
@@ -24,6 +24,7 @@
 import { useCallback, useRef, useState } from 'react';
 
 import type { NormalizedPrototype as Prototype } from '@/lib/api/prototypes';
+import { logger } from '../logger.client';
 
 /**
  * A single UI slot representing one fetch operation and its renderable state.
@@ -149,6 +150,7 @@ export function usePrototypeSlots(
       if (simulateDelay) {
         const { min, max } = simulateDelay;
         const randomDelayMs = Math.random() * (max - min) + min;
+        logger.debug('Simulating network delay of', randomDelayMs, 'ms');
         await new Promise((resolve) => {
           window.setTimeout(resolve, randomDelayMs);
         });

--- a/lib/utils/resolve-play-mode.ts
+++ b/lib/utils/resolve-play-mode.ts
@@ -26,12 +26,23 @@ export const buildPlaylistPlayModeState = (
   title: params.title,
 });
 
+export const buildUnleashedPlayModeState = (): PlayModeState => ({
+  type: 'unleashed',
+});
+
+export const buildJoePlayModeState = (): PlayModeState => ({
+  type: 'joe',
+});
+
 /**
  * Resolves the play mode based on the provided direct launch parameters.
  */
 export const resolvePlayMode = ({
   directLaunchResult,
 }: ResolvePlayModeArgs): PlayModeState => {
+  // testing unleashed mode
+  // return buildUnleashedPlayModeState();
+
   // Early return if direct launch result is missing or failed
   if (!directLaunchResult || directLaunchResult.type !== 'success') {
     return buildNormalPlayModeState();
@@ -39,12 +50,23 @@ export const resolvePlayMode = ({
 
   // Determine PlayMode
   const directLaunchParams = directLaunchResult.value;
+  console.debug('directLaunchParams:', directLaunchParams);
+
+  // Unleashed mode
+  if (directLaunchParams.unleashed != null) {
+    return buildUnleashedPlayModeState();
+  }
+
+  // Joe mode
+  if (directLaunchParams.joe != null) {
+    return buildJoePlayModeState();
+  }
+
+  // Playlist mode
   const hasIds = directLaunchParams.ids.length > 0;
   const hasTitle =
     typeof directLaunchParams.title === 'string' &&
     directLaunchParams.title.trim().length > 0;
-
-  // Playlist mode
   if (hasIds || hasTitle) {
     return buildPlaylistPlayModeState({
       ids: directLaunchParams.ids,

--- a/lib/validation/validation.ts
+++ b/lib/validation/validation.ts
@@ -21,10 +21,14 @@ export const parseDirectLaunchParams = (
 ): Result<DirectLaunchParams, ValidationError> => {
   const rawIds = searchParams.getAll('id');
   const rawTitle = searchParams.get('title');
+  const rawUnleashed = searchParams.get('unleashed');
+  const rawJoe = searchParams.get('joe');
 
   const parseResult = directLaunchSchema.safeParse({
     id: normalizeIdsInput(rawIds),
     title: rawTitle,
+    unleashed: rawUnleashed != null ? true : undefined,
+    joe: rawJoe != null ? true : undefined,
   });
 
   // Error aggregation
@@ -47,6 +51,8 @@ export const parseDirectLaunchParams = (
     value: {
       ids: parseResult.data.id ?? [],
       title: normalizedTitle,
+      unleashed: parseResult.data.unleashed,
+      joe: parseResult.data.joe,
     },
   };
 };

--- a/schemas/direct-launch.ts
+++ b/schemas/direct-launch.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 export type DirectLaunchParams = {
   ids: number[];
   title?: string;
+  unleashed?: boolean;
+  joe?: boolean;
 };
 
 export const directLaunchSchema = z.object({
@@ -27,4 +29,8 @@ export const directLaunchSchema = z.object({
     .max(300, { message: 'Title must be 300 characters or less.' })
     .nullable()
     .optional(),
+
+  unleashed: z.boolean().optional(),
+
+  joe: z.boolean().optional(),
 });

--- a/types/mugen-protopedia.types.ts
+++ b/types/mugen-protopedia.types.ts
@@ -3,7 +3,7 @@
  * - 'normal': Standard browsing mode.
  * - 'playlist': Playlist mode for sequential prototype viewing.
  */
-export type PlayMode = 'normal' | 'playlist';
+export type PlayMode = 'normal' | 'playlist' | 'unleashed' | 'joe';
 
 type BasePlayModeState<T extends PlayMode> = {
   type: T;
@@ -16,7 +16,17 @@ export type PlaylistPlayModeState = BasePlayModeState<'playlist'> & {
   title?: string;
 };
 
-export type PlayModeState = NormalPlayModeState | PlaylistPlayModeState;
+export type UnleashedPlayModeState = BasePlayModeState<'unleashed'>;
+export type JoePlayModeState = BasePlayModeState<'joe'>;
+
+export type PlayModeState =
+  | NormalPlayModeState
+  | PlaylistPlayModeState
+  | UnleashedPlayModeState
+  | JoePlayModeState;
+
+export type SimulatedDelayRange = { min: number; max: number };
+export type SimulatedDelayRangeByMode = Record<PlayMode, SimulatedDelayRange>;
 
 /**
  * Control panel mode of the ProtoPedia Viewer.


### PR DESCRIPTION
This PR tunes playlist delays per play mode and introduces special play modes for power users.

### Changes

- **Play modes**
  - Add `unleashed` and `joe` play modes resolved from direct launch params.
  - Wire `?unleashed` / `?joe` flags through `directLaunchSchema` and `parseDirectLaunchParams`.
  - Update `resolvePlayMode` to prefer `unleashed` / `joe` before playlist/normal.
  - Show current play mode in `Header` (Normal / Playlist / Unleashed / Joe) when `NODE_ENV === 'development'`.

- **Delay tuning**
  - Introduce `SimulatedDelayRangeByMode` keyed by play mode.
  - Configure ranges:
    - `normal`: 500–2000ms
    - `playlist`: 500–1000ms
    - `unleashed` / `joe`: 0ms (no artificial delay)
  - Pass mode-specific `simulateDelayRangeMs` into `usePrototypeSlots` from `MugenProtoPedia`.

- **Validation & tests**
  - Extend `DirectLaunchParams` schema with `unleashed` and `joe` boolean flags.
  - Treat presence of `?unleashed` / `?joe` as `true`.
  - Update `parseDirectLaunchParams` tests to cover the new flags.

All existing tests pass locally with `npm run test`.