### PR TITLE
feat: disable text selection on header and control panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
+
+### Changed
+
+- Disable text selection on the header and the control panel to prevent
+  labels and emojis from being accidentally selected on click or drag. The
+  prototype ID input remains selectable.
+- Remove background color classes from the StatusIndicator component.

--- a/components/control-panel.tsx
+++ b/components/control-panel.tsx
@@ -181,7 +181,7 @@ function SubPanel({
         max={99999}
         value={prototypeIdInput}
         onChange={onPrototypeIdInputChange}
-        className={`${PANEL_BORDER} w-24 rounded p-2 text-base text-center tracking-widest bg-white dark:bg-gray-800 text-gray-900 dark:text-white transition-colors duration-200`}
+        className={`${PANEL_BORDER} w-24 rounded p-2 text-base text-center tracking-widest bg-white dark:bg-gray-800 text-gray-900 dark:text-white transition-colors duration-200 select-text`}
         placeholder="ID"
         disabled={!canGetPrototypes}
       />

--- a/components/control-panel.tsx
+++ b/components/control-panel.tsx
@@ -255,7 +255,7 @@ export function ControlPanel({
   });
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-1 select-none">
       <MainPanel
         onClear={onClear}
         onGetRandomPrototype={onGetRandomPrototype}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -66,7 +66,7 @@ export const Header = forwardRef<HTMLDivElement, HeaderProps>(function Header(
   return (
     <div
       ref={ref}
-      className="fixed top-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-gray-900/50 transition-colors duration-200"
+      className="select-none fixed top-0 left-0 right-0 z-50 bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-gray-900/50 transition-colors duration-200"
     >
       <div className="p-2 sm:p-4 space-y-1.5 sm:space-y-4">
         <div className="flex items-center justify-between gap-1.5 sm:gap-4">

--- a/components/status-indicator.tsx
+++ b/components/status-indicator.tsx
@@ -19,10 +19,8 @@ export function StatusIndicator({
     <span
       className={cn(
         'flex items-center justify-center w-6 h-6 rounded',
-        variant === 'gray' &&
-          'bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-100',
-        variant === 'blue' &&
-          'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-100',
+        variant === 'gray' && ' text-gray-800 dark:text-gray-100',
+        variant === 'blue' && ' text-blue-800 dark:text-blue-100',
         pulse && 'animate-pulse',
         className,
       )}


### PR DESCRIPTION
## Overview

Add `select-none` to the header and the control panel so that their text and emojis are not accidentally selected on click or drag.

## Changes

- **`components/header.tsx`**: Add `select-none` to the header root `div`. The title, play mode label, dashboard, and header buttons (including emojis) become non-selectable.
- **`components/control-panel.tsx`**: Add `select-none` to the top-level container (`div.space-y-1`). Button labels such as RESET / PROTOTYPE / SHOW / More / Less become non-selectable. The prototype ID input (`<input>`) remains selectable and editable as intended.
- **`components/status-indicator.tsx`**: Remove the per-variant background color classes from StatusIndicator (keep only the text color).
- **`CHANGELOG.md`**: Document the changes above under `[Unreleased]`.

## Notes

`user-select: none` is an inherited property, so adding it once to each container root propagates to all descendants. Form elements (`<input>`) override the inherited value via the user-agent stylesheet, so the ID input stays selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)